### PR TITLE
Fix link to GUIDE.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </p>
 
 ## Usage
-[See the documentaion](../docs/GUIDE.md) for instructions on how to use it.
+[See the documentaion](../main/docs/GUIDE.md) for instructions on how to use it.
 
 ## Build
 ### Requirements


### PR DESCRIPTION
## Summary
The link to GUIDE.md in README.md was broke. I moved it to "blob/main/".

## PR type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Update
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] Documentation content changes

## What is the current behavior?

Clicking on the link under "Usage" leads to a 404 page.

## What is the new behavior?

Clicking on the link under "Usage" leads to README.md.